### PR TITLE
Add GPDB master branch (PG 9.1) support

### DIFF
--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -31,8 +31,12 @@ int Backend_setJavaLogLevel(int logLevel);
 #error The macro PG_GETCONFIGOPTION needs to be renamed.
 #endif
 
-/* PG_VERSION_NUM >= 80400 is for GPDB compatible*/
-#if PG_VERSION_NUM >= 90100
+/* 
+ * PG_VERSION_NUM >= 80400 is for GPDB5 compatible
+ * Change PG_VERSION_NUM >= 90200 (from 90100) for master
+ * branch compatible
+ */
+#if PG_VERSION_NUM >= 90200
 #define PG_GETCONFIGOPTION(key) GetConfigOption(key, false, true)
 #elif PG_VERSION_NUM >= 90000
 #define PG_GETCONFIGOPTION(key) GetConfigOption(key, true)


### PR DESCRIPTION
The GetConfigOption() is not changed in GPDB master branch (PG 9.1),
but has been changed in PG 9.1 Stable. So update marco of pljava
to not change this in current GPDB master.

No test needed as this commit do not container any behavior changing