### PR TITLE
Add support to use `CREATE EXTENSION pljava` and fix answer files without optimizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ JAVA_HOME := $(PLJAVA_HOME)
 
 PLJAVADATA = $(DESTDIR)$(datadir)/pljava
 PLJAVALIB  = $(DESTDIR)$(pkglibdir)/java
+PLJAVAEXT  = $(DESTDIR)$(datadir)/extension
 
 REGRESS_OPTS = --dbname=pljava_test --create-role=pljava_test
-REGRESS = pljava_init pljava_functions pljava_test
+REGRESS = pljava_ext_init pljava_functions pljava_test pljava_ext_cleanup pljava_init pljava_functions pljava_test
 REGRESS_DIR = $(top_builddir)
 
 .DEFAULT_GOAL := build
@@ -56,6 +57,8 @@ install: installdirs install-lib
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/install.sql'                                    '$(PLJAVADATA)'
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/uninstall.sql'                                  '$(PLJAVADATA)'
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/examples.sql'                                   '$(PLJAVADATA)'
+	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/pljava--1.5.0.sql'                              '$(PLJAVAEXT)'
+	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/pljava.control'                                 '$(PLJAVAEXT)'
 	find $(PROJDIR)/docs -name "*.html" -exec $(INSTALL_DATA) {} '$(PLJAVADATA)/docs' \;
 
 uninstall: uninstall-lib 

--- a/gpdb/installation/pljava--1.5.0.sql
+++ b/gpdb/installation/pljava--1.5.0.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION java_call_handler()  RETURNS language_handler AS '$libdir/pljava' LANGUAGE C;
+CREATE FUNCTION javau_call_handler() RETURNS language_handler AS '$libdir/pljava' LANGUAGE C;
+CREATE TRUSTED LANGUAGE java HANDLER java_call_handler;
+CREATE LANGUAGE javaU HANDLER javau_call_handler;

--- a/gpdb/installation/pljava.control
+++ b/gpdb/installation/pljava.control
@@ -1,0 +1,6 @@
+# pljava extension
+comment = 'PL/Java procedural language (https://tada.github.io/pljava/)'
+default_version = '1.5.0'
+module_pathname = '$libdir/pljava'
+encoding = UTF8
+relocatable = true

--- a/gpdb/tests/expected/pljava_ext_cleanup.out
+++ b/gpdb/tests/expected/pljava_ext_cleanup.out
@@ -1,0 +1,68 @@
+-- cleanup schema and functions used by `create extension pljava`
+DROP SCHEMA IF EXISTS javatest CASCADE;
+NOTICE:  drop cascades to 64 other objects
+DETAIL:  drop cascades to function javatest.java_gettimestamp()
+drop cascades to function javatest.java_gettimestamptz()
+drop cascades to function javatest.print(date)
+drop cascades to function javatest.print(time with time zone)
+drop cascades to function javatest.print(timestamp with time zone)
+drop cascades to function javatest.print(character varying)
+drop cascades to function javatest.print(bytea)
+drop cascades to function javatest.print(smallint)
+drop cascades to function javatest.print(smallint[])
+drop cascades to function javatest.print(integer)
+drop cascades to function javatest.print(integer[])
+drop cascades to function javatest.print(bigint)
+drop cascades to function javatest.print(bigint[])
+drop cascades to function javatest.print(real)
+drop cascades to function javatest.print(real[])
+drop cascades to function javatest.print(double precision)
+drop cascades to function javatest.print(double precision[])
+drop cascades to function javatest.printobj(integer[])
+drop cascades to function javatest.java_addone(integer)
+drop cascades to function javatest.nulloneven(integer)
+drop cascades to function javatest.addnumbers(smallint,integer,bigint,numeric,numeric,real,double precision)
+drop cascades to function javatest.countnulls(record)
+drop cascades to function javatest.countnulls(integer[])
+drop cascades to function javatest.java_getsystemproperty(character varying)
+drop cascades to function javatest.create_temp_file_trusted()
+drop cascades to type javatest._testsetreturn
+drop cascades to function javatest.tuplereturnexample(integer,integer)
+drop cascades to function javatest.tuplereturnexample2(integer,integer)
+drop cascades to function javatest.tuplereturntostring(javatest._testsetreturn)
+drop cascades to function javatest.setreturnexample(integer,integer)
+drop cascades to function javatest.hugeresult(integer)
+drop cascades to function javatest.hugenonimmutableresult(integer)
+drop cascades to function javatest.listsupers()
+drop cascades to function javatest.listnonsupers()
+drop cascades to type javatest._properties
+drop cascades to function javatest.propertyexample()
+drop cascades to function javatest.resultsetpropertyexample()
+drop cascades to function javatest.scalarpropertyexample()
+drop cascades to function javatest.randomints(integer)
+drop cascades to function javatest.logmessage(character varying,character varying)
+drop cascades to type javatest.binarycolumnpair
+drop cascades to function javatest.binarycolumntest()
+drop cascades to type javatest.metadatabooleans
+drop cascades to function javatest.getmetadatabooleans()
+drop cascades to type javatest.metadatastrings
+drop cascades to function javatest.getmetadatastrings()
+drop cascades to type javatest.metadataints
+drop cascades to function javatest.getmetadataints()
+drop cascades to function javatest.callmetadatamethod(character varying)
+drop cascades to function javatest.executeselect(character varying)
+drop cascades to function javatest.executeselecttorecords(character varying)
+drop cascades to function javatest.loganyelement(anyelement)
+drop cascades to function javatest.logany("any")
+drop cascades to function javatest.makearray(anyelement)
+drop cascades to table javatest.employees1
+drop cascades to table javatest.employees2
+drop cascades to function javatest.transferpeople(integer)
+drop cascades to function javatest.maxfromsetreturnexample(integer,integer)
+drop cascades to function javatest.nestedstatements(integer)
+drop cascades to function javatest.testsavepointsanity()
+drop cascades to function javatest.testtransactionrecovery()
+drop cascades to function javatest.getdateasstring()
+drop cascades to function javatest.gettimeasstring()
+drop cascades to table javatest.test
+DROP EXTENSION pljava;

--- a/gpdb/tests/expected/pljava_ext_init.out
+++ b/gpdb/tests/expected/pljava_ext_init.out
@@ -1,0 +1,4 @@
+CREATE EXTENSION pljava;
+alter database pljava_test owner to pljava_test;
+\c pljava_test pljava_test
+CREATE SCHEMA javatest;

--- a/gpdb/tests/expected/pljava_test.out
+++ b/gpdb/tests/expected/pljava_test.out
@@ -54,7 +54,7 @@ SELECT * FROM javatest.print('12:34:56-00'::time);
 SELECT javatest.print('2016-02-14 08:09:10'::timestamp);
                   print                   
 ------------------------------------------
- Sunday, February 14, 2016 8:09:10 AM UTC 
+ Sunday, February 14, 2016 8:09:10 AM UTC
 (1 row)
 
 SELECT javatest.print('2016-02-14 08:09:10'::timestamp) FROM javatest.test;
@@ -88,21 +88,21 @@ SELECT * FROM javatest.print('varchar'::varchar);
  varchar
 (1 row)
 
-SELECT javatest.print('bytea'::bytea);
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT javatest.print('bytea'::bytea) FROM javatest.test;
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape') FROM javatest.test;
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT * FROM javatest.print('bytea'::bytea);
- print 
--------
+SELECT * FROM encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
@@ -399,11 +399,11 @@ SELECT javatest.java_getSystemProperty('user.language');
  * prohibited when the language is trusted.
  */
 SELECT javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT javatest.create_temp_file_trusted() FROM javatest.test;
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)  (seg0 slice1 pljava.pivotal.io:40000 pid=14850) (cdbdisp.c:215)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT * FROM javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 -- org.postgresql.pljava.example.TupleReturn
 select base, incbase from javatest.tupleReturnExample(2,4);
  base | incbase 
@@ -605,9 +605,9 @@ select javatest.loganyelement('a'::varchar);
  a
 (1 row)
 
-select javatest.loganyelement('b'::bytea);
- loganyelement 
----------------
+select encode(javatest.loganyelement('b'::bytea), 'escape');
+ encode 
+--------
  b
 (1 row)
 
@@ -649,8 +649,8 @@ SELECT id,name, salary FROM employees2 order by id;
 -- s/\(SOMEFILE\:SOMEFUNC\)//
 -- end_matchsubs
 SELECT javatest.transferPeople(1) FROM javatest.test;  -- should error
-ERROR:  function cannot execute on segment because it accesses relation "javatest.employees1"
-DETAIL:  SQL statement "SELECT id, name, salary FROM employees1 WHERE salary > $1"
+ERROR:  function cannot execute on a QE slice because it accesses relation "javatest.employees1"
+CONTEXT:  SQL statement "SELECT id, name, salary FROM employees1 WHERE salary > $1"
 select javatest.maxFromSetReturnExample(2,10);
  maxfromsetreturnexample 
 -------------------------

--- a/gpdb/tests/expected/pljava_test_1.out
+++ b/gpdb/tests/expected/pljava_test_1.out
@@ -67,6 +67,7 @@ SELECT * FROM javatest.print('2016-02-14 08:09:10'::timestamp);
                                print                                
 --------------------------------------------------------------------
  Sunday, February 14, 2016 at 8:09:10 AM Coordinated Universal Time
+(1 row)
 
  
 SELECT javatest.print('varchar'::varchar);
@@ -87,21 +88,21 @@ SELECT * FROM javatest.print('varchar'::varchar);
  varchar
 (1 row)
 
-SELECT javatest.print('bytea'::bytea);
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT javatest.print('bytea'::bytea) FROM javatest.test;
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape') FROM javatest.test;
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT * FROM javatest.print('bytea'::bytea);
- print 
--------
+SELECT * FROM encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
@@ -398,11 +399,11 @@ SELECT javatest.java_getSystemProperty('user.language');
  * prohibited when the language is trusted.
  */
 SELECT javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT javatest.create_temp_file_trusted() FROM javatest.test;
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)  (seg0 slice1 pljava.pivotal.io:40000 pid=14850) (cdbdisp.c:215)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT * FROM javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 -- org.postgresql.pljava.example.TupleReturn
 select base, incbase from javatest.tupleReturnExample(2,4);
  base | incbase 
@@ -604,9 +605,9 @@ select javatest.loganyelement('a'::varchar);
  a
 (1 row)
 
-select javatest.loganyelement('b'::bytea);
- loganyelement 
----------------
+select encode(javatest.loganyelement('b'::bytea), 'escape');
+ encode 
+--------
  b
 (1 row)
 
@@ -648,8 +649,8 @@ SELECT id,name, salary FROM employees2 order by id;
 -- s/\(SOMEFILE\:SOMEFUNC\)//
 -- end_matchsubs
 SELECT javatest.transferPeople(1) FROM javatest.test;  -- should error
-ERROR:  function cannot execute on segment because it accesses relation "javatest.employees1"
-DETAIL:  SQL statement "SELECT id, name, salary FROM employees1 WHERE salary > $1"
+ERROR:  function cannot execute on a QE slice because it accesses relation "javatest.employees1"
+CONTEXT:  SQL statement "SELECT id, name, salary FROM employees1 WHERE salary > $1"
 select javatest.maxFromSetReturnExample(2,10);
  maxfromsetreturnexample 
 -------------------------

--- a/gpdb/tests/sql/pljava_ext_cleanup.sql
+++ b/gpdb/tests/sql/pljava_ext_cleanup.sql
@@ -1,0 +1,3 @@
+-- cleanup schema and functions used by `create extension pljava`
+DROP SCHEMA IF EXISTS javatest CASCADE;
+DROP EXTENSION pljava;

--- a/gpdb/tests/sql/pljava_ext_init.sql
+++ b/gpdb/tests/sql/pljava_ext_init.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION pljava;
+
+alter database pljava_test owner to pljava_test;
+
+\c pljava_test pljava_test
+
+CREATE SCHEMA javatest;


### PR DESCRIPTION
    Previously, DBA enable pljava by running `psql -d mydatabase -f
    $GPHOME/share/postgresql/pljava/install.sql` after installing pljava-*.gppkg.
    Currently, we want to enable pljava by `CREATE EXTENSION pljava;`.
    But we still keep the old style.
    For some files:
    install.sql and uninstall.sql used by old method
    pljava--1.5.0.sql and pljava.control are used by new method