### PR TITLE
Change the bucket of the output artifact except the released

### DIFF
--- a/concourse/pipeline/pipeline_pljava.yml
+++ b/concourse/pipeline/pipeline_pljava.yml
@@ -153,28 +153,28 @@ resources:
 - name: pljava_gpdb_centos6_build
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/published/gpdb6/pljava-rhel6.gppkg
 
 - name: pljava_gpdb_centos7_build
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/published/gpdb6/pljava-rhel7.gppkg
 
 - name: pljava_gpdb_sles11_build
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/published/gpdb6/pljava-sles11.gppkg
 
 - name: pljava_gpdb_ubuntu16_build
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/published/gpdb6/pljava-ubuntu16.gppkg
 
@@ -209,28 +209,28 @@ resources:
 - name: pljava_gpdb_centos6_release_candidate
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/release_candidate/gpdb6/pljava-(.*)-rhel6-x86_64.gppkg
 
 - name: pljava_gpdb_centos7_release_candidate
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/release_candidate/gpdb6/pljava-(.*)-rhel7-x86_64.gppkg
 
 - name: pljava_gpdb_sles11_release_candidate
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/release_candidate/gpdb6/pljava-(.*)-sles11-x86_64.gppkg
 
 - name: pljava_gpdb_ubuntu16_release_candidate
   type: gcs
   source:
-    bucket: {{gcs-bucket}}
+    bucket: {{gcs-bucket-intermediates}}
     json_key: {{gcs-read-write-service-account-key}}
     regexp: pljava/release_candidate/gpdb6/pljava-(.*)-ubuntu16-amd64.gppkg
 
@@ -689,7 +689,7 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_src
-    - get: release_trigger
+      resource: release_trigger
       trigger: true
     - get: pljava_bin
       resource: pljava_gpdb_centos7_build
@@ -710,7 +710,7 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_src
-    - get: release_trigger
+      resource: release_trigger
       trigger: true
     - get: pljava_bin
       resource: pljava_gpdb_centos6_build
@@ -731,7 +731,7 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_src
-    - get: release_trigger
+      resource: release_trigger
       trigger: true
     - get: pljava_bin
       resource: pljava_gpdb_sles11_build
@@ -752,7 +752,7 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_src
-    - get: release_trigger
+      resource: release_trigger
       trigger: true
     - get: pljava_bin
       resource: pljava_gpdb_ubuntu16_build
@@ -774,7 +774,9 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_centos7_img
+      trigger: false
     - get: pljava_gpdb_centos7_release_candidate
+      trigger: false
   - task: Copy_GPPKG
     image: pljava_centos7_img
     config:
@@ -798,7 +800,9 @@ jobs:
   plan:
   - aggregate:
     - get: pljava_centos6_img
+      trigger: false
     - get: pljava_gpdb_centos6_release_candidate
+      trigger: false
   - task: Copy_GPPKG
     image: pljava_centos6_img
     config:


### PR DESCRIPTION
Move output artifact except the released to bucket pivotal-gpdb-concourse-resources-intermediates-prod.
Previously, pipeline uses bucket pivotal-gpdb-concourse-resources-prod which is immutable. But there is no version control, so overwrite causes errors.