### PR TITLE
Add support for `CREATE EXTENSION pljava;` and Fix answer files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ JAVA_HOME := $(PLJAVA_HOME)
 
 PLJAVADATA = $(DESTDIR)$(datadir)/pljava
 PLJAVALIB  = $(DESTDIR)$(pkglibdir)/java
+PLJAVAEXT  = $(DESTDIR)$(datadir)/extension
 
 REGRESS_OPTS = --dbname=pljava_test --create-role=pljava_test
-REGRESS = pljava_init pljava_functions pljava_test
+REGRESS = pljava_ext_init pljava_functions pljava_test pljava_ext_cleanup pljava_init pljava_functions pljava_test
 REGRESS_DIR = $(top_builddir)
 
 .DEFAULT_GOAL := build
@@ -49,6 +50,7 @@ installdirs:
 	$(MKDIR_P) '$(PLJAVALIB)'
 	$(MKDIR_P) '$(PLJAVADATA)'
 	$(MKDIR_P) '$(PLJAVADATA)/docs'
+	$(MKDIR_P) '$(PLJAVAEXT)'
 
 install: installdirs install-lib
 	$(INSTALL_DATA) '$(PROJDIR)/pljava/target/pljava-$(PLJAVA_OSS_VERSION).jar'                   '$(PLJAVALIB)/pljava.jar'
@@ -56,6 +58,8 @@ install: installdirs install-lib
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/install.sql'                                    '$(PLJAVADATA)'
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/uninstall.sql'                                  '$(PLJAVADATA)'
 	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/examples.sql'                                   '$(PLJAVADATA)'
+	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/pljava--1.5.0.sql'                              '$(PLJAVAEXT)'
+	$(INSTALL_DATA) '$(PROJDIR)/gpdb/installation/pljava.control'                                 '$(PLJAVAEXT)'
 	find $(PROJDIR)/docs -name "*.html" -exec $(INSTALL_DATA) {} '$(PLJAVADATA)/docs' \;
 
 uninstall: uninstall-lib 

--- a/gpdb/installation/pljava--1.5.0.sql
+++ b/gpdb/installation/pljava--1.5.0.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION java_call_handler()  RETURNS language_handler AS '$libdir/pljava' LANGUAGE C;
+CREATE FUNCTION javau_call_handler() RETURNS language_handler AS '$libdir/pljava' LANGUAGE C;
+CREATE TRUSTED LANGUAGE java HANDLER java_call_handler;
+CREATE LANGUAGE javaU HANDLER javau_call_handler;

--- a/gpdb/installation/pljava.control
+++ b/gpdb/installation/pljava.control
@@ -1,0 +1,6 @@
+# pljava extension
+comment = 'PL/Java procedural language (https://tada.github.io/pljava/)'
+default_version = '1.5.0'
+module_pathname = '$libdir/pljava'
+encoding = UTF8
+relocatable = true

--- a/gpdb/packaging/gppkg_spec.yml.in
+++ b/gpdb/packaging/gppkg_spec.yml.in
@@ -7,4 +7,4 @@ Description: Provides a procedural language implementation of Java for the Green
 PostInstall:
 - Master:  "echo 'Please SET JAVA_HOME firstly.';
             echo 'Please source your $GPHOME/greenplum_path.sh file and restart the database.';
-            echo 'You can enable pljava by running psql -d mydatabase -f $GPHOME/share/postgresql/pljava/install.sql.' ;"
+            echo 'You can enable pljava by running -> CREATE EXTENSION pljava;' ;"

--- a/gpdb/tests/expected/pljava_ext_cleanup.out
+++ b/gpdb/tests/expected/pljava_ext_cleanup.out
@@ -1,0 +1,67 @@
+-- cleanup schema and functions used by `create extension pljava`
+DROP SCHEMA IF EXISTS javatest CASCADE;
+NOTICE:  drop cascades to table javatest.test
+NOTICE:  drop cascades to function javatest.gettimeasstring()
+NOTICE:  drop cascades to function javatest.getdateasstring()
+NOTICE:  drop cascades to function javatest.testtransactionrecovery()
+NOTICE:  drop cascades to function javatest.testsavepointsanity()
+NOTICE:  drop cascades to function javatest.nestedstatements(integer)
+NOTICE:  drop cascades to function javatest.maxfromsetreturnexample(integer,integer)
+NOTICE:  drop cascades to function javatest.transferpeople(integer)
+NOTICE:  drop cascades to table javatest.employees2
+NOTICE:  drop cascades to table javatest.employees1
+NOTICE:  drop cascades to function javatest.makearray(anyelement)
+NOTICE:  drop cascades to function javatest.logany("any")
+NOTICE:  drop cascades to function javatest.loganyelement(anyelement)
+NOTICE:  drop cascades to function javatest.executeselecttorecords(character varying)
+NOTICE:  drop cascades to function javatest.executeselect(character varying)
+NOTICE:  drop cascades to function javatest.callmetadatamethod(character varying)
+NOTICE:  drop cascades to function javatest.getmetadataints()
+NOTICE:  drop cascades to type javatest.metadataints
+NOTICE:  drop cascades to function javatest.getmetadatastrings()
+NOTICE:  drop cascades to type javatest.metadatastrings
+NOTICE:  drop cascades to function javatest.getmetadatabooleans()
+NOTICE:  drop cascades to type javatest.metadatabooleans
+NOTICE:  drop cascades to function javatest.binarycolumntest()
+NOTICE:  drop cascades to type javatest.binarycolumnpair
+NOTICE:  drop cascades to function javatest.logmessage(character varying,character varying)
+NOTICE:  drop cascades to function javatest.randomints(integer)
+NOTICE:  drop cascades to function javatest.scalarpropertyexample()
+NOTICE:  drop cascades to function javatest.resultsetpropertyexample()
+NOTICE:  drop cascades to function javatest.propertyexample()
+NOTICE:  drop cascades to type javatest._properties
+NOTICE:  drop cascades to function javatest.listnonsupers()
+NOTICE:  drop cascades to function javatest.listsupers()
+NOTICE:  drop cascades to function javatest.hugenonimmutableresult(integer)
+NOTICE:  drop cascades to function javatest.hugeresult(integer)
+NOTICE:  drop cascades to function javatest.setreturnexample(integer,integer)
+NOTICE:  drop cascades to function javatest.tuplereturntostring(javatest._testsetreturn)
+NOTICE:  drop cascades to function javatest.tuplereturnexample2(integer,integer)
+NOTICE:  drop cascades to function javatest.tuplereturnexample(integer,integer)
+NOTICE:  drop cascades to type javatest._testsetreturn
+NOTICE:  drop cascades to function javatest.create_temp_file_trusted()
+NOTICE:  drop cascades to function javatest.java_getsystemproperty(character varying)
+NOTICE:  drop cascades to function javatest.countnulls(integer[])
+NOTICE:  drop cascades to function javatest.countnulls(record)
+NOTICE:  drop cascades to function javatest.addnumbers(smallint,integer,bigint,numeric,numeric,real,double precision)
+NOTICE:  drop cascades to function javatest.nulloneven(integer)
+NOTICE:  drop cascades to function javatest.java_addone(integer)
+NOTICE:  drop cascades to function javatest.printobj(integer[])
+NOTICE:  drop cascades to function javatest.print(double precision[])
+NOTICE:  drop cascades to function javatest.print(double precision)
+NOTICE:  drop cascades to function javatest.print(real[])
+NOTICE:  drop cascades to function javatest.print(real)
+NOTICE:  drop cascades to function javatest.print(bigint[])
+NOTICE:  drop cascades to function javatest.print(bigint)
+NOTICE:  drop cascades to function javatest.print(integer[])
+NOTICE:  drop cascades to function javatest.print(integer)
+NOTICE:  drop cascades to function javatest.print(smallint[])
+NOTICE:  drop cascades to function javatest.print(smallint)
+NOTICE:  drop cascades to function javatest.print(bytea)
+NOTICE:  drop cascades to function javatest.print(character varying)
+NOTICE:  drop cascades to function javatest.print(timestamp with time zone)
+NOTICE:  drop cascades to function javatest.print(time with time zone)
+NOTICE:  drop cascades to function javatest.print(date)
+NOTICE:  drop cascades to function javatest.java_gettimestamptz()
+NOTICE:  drop cascades to function javatest.java_gettimestamp()
+DROP EXTENSION pljava;

--- a/gpdb/tests/expected/pljava_ext_init.out
+++ b/gpdb/tests/expected/pljava_ext_init.out
@@ -1,0 +1,4 @@
+CREATE EXTENSION pljava;
+alter database pljava_test owner to pljava_test;
+\c pljava_test pljava_test
+CREATE SCHEMA javatest;

--- a/gpdb/tests/expected/pljava_test.out
+++ b/gpdb/tests/expected/pljava_test.out
@@ -54,7 +54,7 @@ SELECT * FROM javatest.print('12:34:56-00'::time);
 SELECT javatest.print('2016-02-14 08:09:10'::timestamp);
                   print                   
 ------------------------------------------
- Sunday, February 14, 2016 8:09:10 AM UTC 
+ Sunday, February 14, 2016 8:09:10 AM UTC
 (1 row)
 
 SELECT javatest.print('2016-02-14 08:09:10'::timestamp) FROM javatest.test;
@@ -88,21 +88,21 @@ SELECT * FROM javatest.print('varchar'::varchar);
  varchar
 (1 row)
 
-SELECT javatest.print('bytea'::bytea);
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT javatest.print('bytea'::bytea) FROM javatest.test;
- print 
--------
+SELECT encode(javatest.print('bytea'::bytea), 'escape') FROM javatest.test;
+ encode 
+--------
  bytea
 (1 row)
 
-SELECT * FROM javatest.print('bytea'::bytea);
- print 
--------
+SELECT * FROM encode(javatest.print('bytea'::bytea), 'escape');
+ encode 
+--------
  bytea
 (1 row)
 
@@ -399,11 +399,11 @@ SELECT javatest.java_getSystemProperty('user.language');
  * prohibited when the language is trusted.
  */
 SELECT javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT javatest.create_temp_file_trusted() FROM javatest.test;
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)  (seg0 slice1 pljava.pivotal.io:40000 pid=14850) (cdbdisp.c:215)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 SELECT * FROM javatest.create_temp_file_trusted();
-ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:76)
+ERROR:  java.lang.SecurityException: read on /tmp/pljava_temp.txt (JNICalls.c:78)
 -- org.postgresql.pljava.example.TupleReturn
 select base, incbase from javatest.tupleReturnExample(2,4);
  base | incbase 
@@ -605,9 +605,9 @@ select javatest.loganyelement('a'::varchar);
  a
 (1 row)
 
-select javatest.loganyelement('b'::bytea);
- loganyelement 
----------------
+select encode(javatest.loganyelement('b'::bytea), 'escape');
+ encode 
+--------
  b
 (1 row)
 

--- a/gpdb/tests/sql/pljava_ext_cleanup.sql
+++ b/gpdb/tests/sql/pljava_ext_cleanup.sql
@@ -1,0 +1,3 @@
+-- cleanup schema and functions used by `create extension pljava`
+DROP SCHEMA IF EXISTS javatest CASCADE;
+DROP EXTENSION pljava;

--- a/gpdb/tests/sql/pljava_ext_init.sql
+++ b/gpdb/tests/sql/pljava_ext_init.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION pljava;
+
+alter database pljava_test owner to pljava_test;
+
+\c pljava_test pljava_test
+
+CREATE SCHEMA javatest;


### PR DESCRIPTION
Previously, DBA enable pljava by running `psql -d mydatabase -f
$GPHOME/share/postgresql/pljava/install.sql` after installing pljava-*.gppkg.
Currently, we want to enable pljava by `CREATE EXTENSION pljava;`.
But we still keep the old style.
For some files:
install.sql and uninstall.sql used by old method
pljava--1.5.0.sql and pljava.control are used by new method

Concourse pipeline pulls gpdb with optimized on, so pljava_test.out
is ignored.