### PR TITLE
[GP7 Build 1/3] Handle the retirement of magical oids.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/Triggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example;
 
@@ -35,8 +36,8 @@ import org.postgresql.pljava.TriggerException;
 public class Triggers {
 	public static void afterUsernameInsert(TriggerData td) throws SQLException {
 		Logger log = Logger.getAnonymousLogger();
-		log.info("After username insert, oid of tuple = "
-				+ td.getNew().getInt("oid"));
+		log.info("After username insert, username = "
+				+ td.getNew().getInt("username"));
 	}
 
 	public static void afterUsernameUpdate(TriggerData td) throws SQLException {

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -120,7 +120,7 @@ SQLActions[ ] = {
 			(
 			name		text,
 			username	text not null
-			) WITH OIDS;
+			);
 
 		CREATE FUNCTION javatest.insert_username()
 			RETURNS trigger

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -31,9 +31,15 @@
 #include <utils/memutils.h>
 #include <utils/syscache.h>
 
-#if PG_VERSION_NUM < 90000
+#if PG_VERSION_NUM >= 120000
+#include <catalog/pg_namespace.h>
+#define GetNamespaceOid(k1) \
+	GetSysCacheOid1(NAMESPACENAME, Anum_pg_namespace_oid, k1)
+#elif PG_VERSION_NUM >= 90000
+#define GetNamespaceOid(k1) GetSysCacheOid1(NAMESPACENAME, k1)
+#else
 #define SearchSysCache1(cid, k1) SearchSysCache(cid, k1, 0, 0, 0)
-#define GetSysCacheOid1(cid, k1) GetSysCacheOid(cid, k1, 0, 0, 0)
+#define GetNamespaceOid(k1) GetSysCacheOid(NAMESPACENAME, k1, 0, 0, 0)
 #endif
 
 #include "pljava/InstallHelper.h"
@@ -214,7 +220,7 @@ static void getExtensionLoadPath()
 	 * working model" and that code is a lot more fiddly than you would guess.
 	 */
 	if ( InvalidOid == get_relname_relid(LOADPATH_TBL_NAME,
-		GetSysCacheOid1(NAMESPACENAME, CStringGetDatum("sqlj"))) )
+		GetNamespaceOid(CStringGetDatum("sqlj"))) )
 		return;
 
 	SPI_connect();

--- a/pljava-so/src/main/c/type/AclId.c
+++ b/pljava-so/src/main/c/type/AclId.c
@@ -1,14 +1,19 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <miscadmin.h>
 #include <utils/acl.h>
+#include <catalog/pg_authid.h>
 
 #include "pljava/type/AclId.h"
 #include "pljava/type/Oid.h"
@@ -148,7 +153,13 @@ Java_org_postgresql_pljava_internal_AclId__1fromName(JNIEnv* env, jclass clazz, 
 						(errcode(ERRCODE_UNDEFINED_OBJECT),
 						 errmsg("role \"%s\" does not exist", roleName)));
 
-			result = AclId_create(HeapTupleGetOid(roleTup));
+			result = AclId_create(
+#if PG_VERSION_NUM >= 120000
+				((Form_pg_authid) GETSTRUCT(roleTup))->oid
+#else
+				HeapTupleGetOid(roleTup)
+#endif
+			);
 			ReleaseSysCache(roleTup);
 		}
 		PG_CATCH();


### PR DESCRIPTION
Upstream 578b229 turns the oid columns of system catalogs into
ordinary columns, to be retrieved in the ordinary way by name or
column number. Non-system-catalogs don't get to have system-managed
oids at all any more. (You could give a table an oid-typed column
named oid and make a key of it, but no function is provided to
automatically assign a value to such a column.)

(cherry picked from commit 42dbcea30ea10f1dbb7d0554b889c342e555e37a)
