### PR TITLE
[GP7 Build 3/3] Handle the retirement of dynloader.h.

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2009, 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB - Thomas Hallgren
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <miscadmin.h>
@@ -23,7 +26,19 @@
 #include <catalog/catalog.h>
 #include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
-#include <dynloader.h>
+
+#if PG_VERSION_NUM >= 120000
+ #ifdef HAVE_DLOPEN
+ #include <dlfcn.h>
+ #endif
+ #define pg_dlopen(f) dlopen((f), RTLD_NOW | RTLD_GLOBAL)
+ #define pg_dlsym(h,s) dlsym((h), (s))
+ #define pg_dlclose(h) dlclose((h))
+ #define pg_dlerror() dlerror()
+#else
+ #include <dynloader.h>
+#endif
+
 #include <storage/ipc.h>
 #include <storage/proc.h>
 #include <storage/sinval.h>


### PR DESCRIPTION
Upstream 842cb9f moves to simply expecting dlfcn.h to be present
on most platforms, and covers the rest in port.h (already included
in c.h, which we already include).

(cherry picked from commit f424406496f7b5388ca9d4420e71cc1a729bb88e)
