### PR TITLE
Add -u option for set in test_pljava.sh

### DIFF
--- a/concourse/scripts/test_pljava.sh
+++ b/concourse/scripts/test_pljava.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-set -exo pipefail
+set -exo pipefail -u
 
 function install_pljava() {
     if [ "$GP_MAJOR_VERSION" = "6" ]; then


### PR DESCRIPTION
Treat unset variables and parameters as an error when performing parameter expansion.